### PR TITLE
Logging memory leak and compatibility improvements

### DIFF
--- a/Logging/log.c
+++ b/Logging/log.c
@@ -104,12 +104,14 @@ static void rolling_appender_callback(log_Event *ev) {
   file_callback(ev);
 
   struct stat buf;
-  if (lstat(ev->ra.file_name, &buf) < 0) {
+  if (stat(ev->ra.file_name, &buf) < 0) {
     sprintf(msg, "Unable to stat log file: %s", ev->ra.file_name);
     perror(msg);
     free(msg);
     return;
   }
+
+  free(msg);
 
   if (buf.st_size >= ev->ra.max_log_size) {
     char* old = (char*)calloc(strlen(ev->ra.file_name)+10, sizeof(char));

--- a/Logging/log.h
+++ b/Logging/log.h
@@ -8,12 +8,18 @@
 #ifndef LOG_H
 #define LOG_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -57,5 +63,9 @@ int log_add_rolling_appender(rolling_appender ra, int level);
 int log_add_fp(FILE *fp, int level);
 
 void log_log(int level, const char *file, int line, const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
* Fixed a memory leak in rolling_appender_callback().
* Syntactic sugar addition to make this code compatible with C++.
* Eliminated the lstat() macro in favor of the stat() function.

Closes #10 